### PR TITLE
Transform modules in test environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = declare((api, options) => {
   api.assertVersion('^7.8');
 
   const {
-    modules = 'auto',
+    modules = api.env('test') ? 'commonjs' : 'auto',
     targets = buildTargets(options),
   } = options;
 
@@ -29,7 +29,7 @@ module.exports = declare((api, options) => {
     presets: [
       [require('@babel/preset-env'), {
         debug,
-        modules: modules === false ? false : 'auto',
+        modules,
         targets,
       }],
       [require('@babel/preset-react'), { development }],
@@ -40,7 +40,7 @@ module.exports = declare((api, options) => {
     ],
   };
 
-  if (api.env('production')) {
+  if (!development) {
     config.plugins.push(require('babel-plugin-transform-react-remove-prop-types'));
   }
   return config;


### PR DESCRIPTION
We want to transform modules to commonjs by default when testing.

This PR changes the default value for module transformation when in the test environment.

It also changes the caching key from a boolean value (are we in a development environment?) to a string (which environment are we in?) because we now have several possible configurations, not just two.

**Requesting feedback on:**
[The documentation on `api.cache`](https://babeljs.io/docs/en/config-files#apicache) is really not great and I can't find a lot of examples to look at. [Airbnb's](https://github.com/airbnb/babel-preset-airbnb/blob/master/index.js) just caches on `process.NODE_ENV === 'development'` which is fine because that is the only distinction based on `NODE_ENV` that they make in the config. However the config also changes on `options.debug` and `options.development` (as does ours) and I can't see how they're accounting for that with their caching strategy. Does anyone have any ideas about this?